### PR TITLE
Partial support for the Dragonboard 401C image

### DIFF
--- a/ffu2img.py3
+++ b/ffu2img.py3
@@ -88,6 +88,9 @@ blockdataaddress = blockdataaddress + (FFUSecHeader.dwChunkSizeInKb*1024)-(block
 logfp.write('Block data chunks begin: ' + str(hex(blockdataaddress)) + '\n')
 print('Block data chunks begin: ' + str(hex(blockdataaddress)))
 
+for i in range(FFUStoreHeader.dwInitialTableCount):
+	readblockdataentry()
+
 iBlock = 0
 oldblockcount = 0
 while iBlock < FFUStoreHeader.dwWriteDescriptorCount:
@@ -99,9 +102,14 @@ while iBlock < FFUStoreHeader.dwWriteDescriptorCount:
 	oldblockcount = CurrentBlockDataEntry.dwBlockCount
 	for key, val in CurrentBlockDataEntry._asdict().items():
 		logfp.write(key + ' = ' + str(val) + '\n')
+	if CurrentBlockDataEntry.dwLocationCount == 0 or CurrentBlockDataEntry.dwDiskAccessMethod == 2:
+		# TODO: fix dwDiskAccessMethod == 2 (seek from end of device)
+		# used on Dragonboard 410C for backup GPT
+		iBlock += 1
+		continue
 	curraddress = ffufp.tell()
 	ffufp.seek(blockdataaddress+(iBlock*FFUStoreHeader.dwBlockSizeInBytes))
-	imgfp.seek(CurrentBlockDataEntry.dwBlockCount*FFUStoreHeader.dwBlockSizeInBytes)
+	imgfp.seek(CurrentBlockDataEntry.dwBlockIndex*FFUStoreHeader.dwBlockSizeInBytes)
 	imgfp.write(ffufp.read(FFUStoreHeader.dwBlockSizeInBytes))
 	ffufp.seek(curraddress)
 	iBlock = iBlock + 1


### PR DESCRIPTION
- Take dwInitialTableCount into account
- Fix image seek index

This results in an _almost_ complete DragonBoard 401C image - the DISK_END dwDiskAccessMethod isn't implemented yet, so parted complains that the image is truncated and missing the backup GPT at the end. Is there a way to implement DISK_END without knowing the correct size of the final image in advance? Do you have any ideas?

Also, this is not tested with the Raspberry Pi image, or tested against other ffu converters.
